### PR TITLE
More methods

### DIFF
--- a/src/main/java/com/mozilla/bagheera/hazelcast/persistence/CompositeMapStore.java
+++ b/src/main/java/com/mozilla/bagheera/hazelcast/persistence/CompositeMapStore.java
@@ -31,10 +31,10 @@ import com.hazelcast.core.MapLoaderLifecycleSupport;
 import com.hazelcast.core.MapStore;
 
 /**
- * A CompositeMapStore consists of two MapStore implementations specified via Hazelcast config. This consists of 
+ * A CompositeMapStore consists of two MapStore implementations specified via Hazelcast config. This consists of
  * setting a MapStore to load data and a second to store data. Currently this doesn't support using the same type
  * of MapStore for both. Typically we use this to load data from HBase and index it with ElasticSearch.
- * 
+ *
  * Example:
  * <map-store enabled="true">
  *  <class-name>com.mozilla.bagheera.hazelcast.persistence.CompositeMapStore</class-name>
@@ -43,18 +43,18 @@ import com.hazelcast.core.MapStore;
  *  ...
  * </map-store>
  */
-public class CompositeMapStore extends MapStoreBase implements MapStore<String, String>, MapLoaderLifecycleSupport {
+public class CompositeMapStore extends MapStoreBase implements MapStore<String, String> {
 
     private static final Logger LOG = Logger.getLogger(CompositeMapStore.class);
-    
+
     private static final String LOAD_MAP_STORE = "hazelcast.composite.load.class.name";
     private static final String STORE_MAP_STORE = "hazelcast.composite.store.class.name";
-    
+
     private MapStore<String,String> loadInstance;
     private boolean loadLifeCycleSupport = false;
     private MapStore<String,String> storeInstance;
     private boolean storeLifeCycleSupport = false;
-    
+
     @SuppressWarnings("unchecked")
     @Override
     public void init(HazelcastInstance hazelcastInstance, Properties properties, String mapName) {
@@ -72,13 +72,13 @@ public class CompositeMapStore extends MapStoreBase implements MapStore<String, 
                 MapLoaderLifecycleSupport mapLoadLifecycle = (MapLoaderLifecycleSupport)loadInstance;
                 mapLoadLifecycle.init(hazelcastInstance, properties, mapName);
             }
-            
+
             Class<?> storeClass = Class.forName(storeClassName);
             if (storeClass == null) {
                 throw new ClassNotFoundException("Store class could not be found");
             }
             storeInstance = (MapStore<String,String>)storeClass.newInstance();
-            
+
             if (storeInstance instanceof MapLoaderLifecycleSupport) {
                 storeLifeCycleSupport = true;
                 MapLoaderLifecycleSupport mapLoadLifecycle = (MapLoaderLifecycleSupport)storeInstance;
@@ -95,7 +95,7 @@ public class CompositeMapStore extends MapStoreBase implements MapStore<String, 
             throw new RuntimeException(e);
         }
     }
-    
+
     @Override
     public void destroy() {
         if (loadLifeCycleSupport) {
@@ -107,7 +107,7 @@ public class CompositeMapStore extends MapStoreBase implements MapStore<String, 
             mapLoadLifecycle.destroy();
         }
     }
-    
+
     @Override
     public String load(String key) {
         // TODO Auto-generated method stub
@@ -129,13 +129,13 @@ public class CompositeMapStore extends MapStoreBase implements MapStore<String, 
     @Override
     public void delete(String key) {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override
     public void deleteAll(Collection<String> keys) {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override

--- a/src/main/java/com/mozilla/bagheera/hazelcast/persistence/ElasticSearchMapStore.java
+++ b/src/main/java/com/mozilla/bagheera/hazelcast/persistence/ElasticSearchMapStore.java
@@ -78,7 +78,7 @@ public class ElasticSearchMapStore extends MapStoreBase implements MapStore<Stri
     public void init(HazelcastInstance hazelcastInstance, Properties properties, String mapName) {
         super.init(hazelcastInstance, properties, mapName);
 
-        String indexName = properties.getProperty("hazelcast.elasticsearch.index", "default");
+        String indexName = properties.getProperty("hazelcast.elasticsearch.index", mapName);
         String typeName = properties.getProperty("hazelcast.elasticsearch.type.name", "data");
 
         initNodeClient(properties);

--- a/src/main/java/com/mozilla/bagheera/hazelcast/persistence/ElasticSearchMapStore.java
+++ b/src/main/java/com/mozilla/bagheera/hazelcast/persistence/ElasticSearchMapStore.java
@@ -97,14 +97,12 @@ public class ElasticSearchMapStore extends MapStoreBase implements MapStore<Stri
 
     @Override
     public String load(String key) {
-        // TODO Auto-generated method stub
-        return null;
+        return es.get(key);
     }
 
     @Override
     public Map<String, String> loadAll(Collection<String> keys) {
-        // TODO Auto-generated method stub
-        return null;
+        return es.fetchAll(keys);
     }
 
     @Override

--- a/src/main/java/com/mozilla/bagheera/hazelcast/persistence/ElasticSearchMapStore.java
+++ b/src/main/java/com/mozilla/bagheera/hazelcast/persistence/ElasticSearchMapStore.java
@@ -115,12 +115,12 @@ public class ElasticSearchMapStore extends MapStoreBase implements MapStore<Stri
 
     @Override
     public void delete(String key) {
-        // TODO Auto-generated method stub
+        es.delete(key);
     }
 
     @Override
     public void deleteAll(Collection<String> keys) {
-        // TODO Auto-generated method stub
+        es.delete(keys);
     }
 
     @Override

--- a/src/main/java/com/mozilla/bagheera/hazelcast/persistence/ElasticSearchMapStore.java
+++ b/src/main/java/com/mozilla/bagheera/hazelcast/persistence/ElasticSearchMapStore.java
@@ -32,11 +32,10 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MapLoaderLifecycleSupport;
 import com.hazelcast.core.MapStore;
 import com.mozilla.bagheera.dao.ElasticSearchDao;
 
-public class ElasticSearchMapStore extends MapStoreBase implements MapStore<String,String>, MapLoaderLifecycleSupport {
+public class ElasticSearchMapStore extends MapStoreBase implements MapStore<String,String> {
 
     public static final String ES_CONFIG_PATH = "hazelcast.elasticsearch.config.path";
     public static final String ES_CLUSTER_NAME = "hazelcast.elasticsearch.cluster.name";
@@ -44,48 +43,48 @@ public class ElasticSearchMapStore extends MapStoreBase implements MapStore<Stri
     public static final String ES_STORE_DATA = "hazelcast.elasticsearch.store.data";
     public static final String ES_TRANSPORT_AUTO_DISCOVER = "hazelcast.elasticsearch.transport.autodiscover";
     public static final String ES_SERVER_LIST = "hazelcast.elasticsearch.server.list";
-    
+
     public static final String ES_LOCAL_DEFAULT = "false";
     public static final String ES_STORE_DATA_DEFAULT = "false";
-    
+
     protected Node esNode;
     protected Client esClient;
     protected ElasticSearchDao es;
-    
+
     private void initNodeClient(Properties properties) {
         NodeBuilder nodeBuilder = nodeBuilder();
         ImmutableSettings.Builder settingsBuilder = ImmutableSettings.settingsBuilder();
         String configFile = properties.getProperty(ES_CONFIG_PATH);
         if (configFile != null) {
             settingsBuilder.loadFromClasspath(configFile);
-        } else {           
+        } else {
             String clusterName = properties.getProperty(ES_CLUSTER_NAME);
             if (clusterName != null) {
                 nodeBuilder.clusterName(clusterName);
             }
-            
+
             boolean localMode = Boolean.parseBoolean(properties.getProperty(ES_LOCAL, ES_LOCAL_DEFAULT));
             nodeBuilder.local(localMode);
-            
+
             boolean storeData = Boolean.parseBoolean(properties.getProperty(ES_STORE_DATA, ES_STORE_DATA_DEFAULT));
             nodeBuilder.client(!storeData).data(storeData);
         }
-        
+
         esNode = nodeBuilder.loadConfigSettings(false).settings(settingsBuilder).node();
         esClient = esNode.client();
     }
-    
+
     @Override
     public void init(HazelcastInstance hazelcastInstance, Properties properties, String mapName) {
         super.init(hazelcastInstance, properties, mapName);
-        
+
         String indexName = properties.getProperty("hazelcast.elasticsearch.index", "default");
         String typeName = properties.getProperty("hazelcast.elasticsearch.type.name", "data");
-        
+
         initNodeClient(properties);
         es = new ElasticSearchDao(esClient, indexName, typeName);
     }
-    
+
     @Override
     public void destroy() {
         if (esClient != null) {
@@ -95,7 +94,7 @@ public class ElasticSearchMapStore extends MapStoreBase implements MapStore<Stri
             esNode.close();
         }
     }
-    
+
     @Override
     public String load(String key) {
         // TODO Auto-generated method stub
@@ -113,7 +112,7 @@ public class ElasticSearchMapStore extends MapStoreBase implements MapStore<Stri
         // TODO Auto-generated method stub
         return null;
     }
-    
+
     @Override
     public void delete(String key) {
         // TODO Auto-generated method stub

--- a/src/main/java/com/mozilla/bagheera/hazelcast/persistence/HBaseMapStore.java
+++ b/src/main/java/com/mozilla/bagheera/hazelcast/persistence/HBaseMapStore.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.Logger;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.MapLoaderLifecycleSupport;
 import com.hazelcast.core.MapStore;
 import com.mozilla.bagheera.dao.HBaseTableDao;
 
@@ -50,7 +49,7 @@ import com.mozilla.bagheera.dao.HBaseTableDao;
  * particular implementation to ever load keys. Therefore only the store and
  * storeAll methods are implemented.
  */
-public class HBaseMapStore extends MapStoreBase implements MapStore<String, String>, MapLoaderLifecycleSupport {
+public class HBaseMapStore extends MapStoreBase implements MapStore<String, String> {
 
     private static final Logger LOG = Logger.getLogger(HBaseMapStore.class);
 
@@ -63,7 +62,7 @@ public class HBaseMapStore extends MapStoreBase implements MapStore<String, Stri
     @Override
     public void init(HazelcastInstance hazelcastInstance, Properties properties, String mapName) {
         super.init(hazelcastInstance, properties, mapName);
-        
+
         Configuration conf = HBaseConfiguration.create();
         for (String name : properties.stringPropertyNames()) {
             if (name.startsWith("hbase.") || name.startsWith("hadoop.") || name.startsWith("zookeeper.")) {
@@ -91,10 +90,10 @@ public class HBaseMapStore extends MapStoreBase implements MapStore<String, Stri
             pool.closeTablePool(table.getTableName());
         }
     }
-    
+
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.hazelcast.core.MapLoader#load(java.lang.Object)
      */
     @Override
@@ -104,7 +103,7 @@ public class HBaseMapStore extends MapStoreBase implements MapStore<String, Stri
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.hazelcast.core.MapLoader#loadAll(java.util.Collection)
      */
     @Override
@@ -115,10 +114,10 @@ public class HBaseMapStore extends MapStoreBase implements MapStore<String, Stri
                 Get g = new Get(Bytes.toBytes(k));
                 gets.add(g);
             }
-            
+
             return table.getAll(keys);
         }
-        
+
         return null;
     }
 
@@ -151,10 +150,10 @@ public class HBaseMapStore extends MapStoreBase implements MapStore<String, Stri
         }
         return keySet;
     }
-    
+
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.hazelcast.core.MapStore#delete(java.lang.Object)
      */
     @Override
@@ -166,7 +165,7 @@ public class HBaseMapStore extends MapStoreBase implements MapStore<String, Stri
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.hazelcast.core.MapStore#deleteAll(java.util.Collection)
      */
     @Override
@@ -178,7 +177,7 @@ public class HBaseMapStore extends MapStoreBase implements MapStore<String, Stri
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.hazelcast.core.MapStore#store(java.lang.Object,
      * java.lang.Object)
      */
@@ -193,7 +192,7 @@ public class HBaseMapStore extends MapStoreBase implements MapStore<String, Stri
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see com.hazelcast.core.MapStore#storeAll(java.util.Map)
      */
     @Override

--- a/src/main/java/com/mozilla/bagheera/hazelcast/persistence/HBaseMapStore.java
+++ b/src/main/java/com/mozilla/bagheera/hazelcast/persistence/HBaseMapStore.java
@@ -45,9 +45,10 @@ import com.mozilla.bagheera.dao.HBaseTableDao;
 
 /**
  * An implementation of Hazelcast's MapStore interface that persists map data to
- * HBase. Due to the general size of data in HBase there is no interest for this
- * particular implementation to ever load keys. Therefore only the store and
- * storeAll methods are implemented.
+ * HBase.
+ * An arbitrary number of maps can be persisted into the same HBase table. To do
+ * this, do not specify a column qualifer in the map configuration: the map name
+ * will be used.
  */
 public class HBaseMapStore extends MapStoreBase implements MapStore<String, String> {
 
@@ -74,8 +75,7 @@ public class HBaseMapStore extends MapStoreBase implements MapStore<String, Stri
         int hbasePoolSize = Integer.parseInt(properties.getProperty("hazelcast.hbase.pool.size", "10"));
         String tableName = properties.getProperty("hazelcast.hbase.table", "default");
         String family = properties.getProperty("hazelcast.hbase.column.family", "data");
-        String columnQualifier = properties.getProperty("hazelcast.hbase.column.qualifier");
-        String qualifier = columnQualifier == null ? "" : columnQualifier;
+        String qualifier = properties.getProperty("hazelcast.hbase.column.qualifier", mapName);
 
         pool = new HTablePool(conf, hbasePoolSize);
         table = new HBaseTableDao(pool, tableName, family, qualifier, prefixDate);

--- a/src/main/java/com/mozilla/bagheera/hazelcast/persistence/MapStoreBase.java
+++ b/src/main/java/com/mozilla/bagheera/hazelcast/persistence/MapStoreBase.java
@@ -21,28 +21,24 @@ package com.mozilla.bagheera.hazelcast.persistence;
 
 import java.util.Properties;
 
-import org.apache.log4j.Logger;
-
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.MapLoaderLifecycleSupport;
 
 public abstract class MapStoreBase implements MapLoaderLifecycleSupport {
 
-    private static final Logger LOG = Logger.getLogger(MapStoreBase.class);
-    
     private static final String ALLOW_LOAD = "hazelcast.allow.load";
     private static final String ALLOW_LOAD_ALL = "hazelcast.allow.load.all";
     private static final String ALLOW_DELETE = "hazelcast.allow.delete";
-    
+
     protected boolean allowLoad = false;
     protected boolean allowLoadAll = false;
     protected boolean allowDelete = false;
-    
+
     protected String mapName;
-    
+
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * com.hazelcast.core.MapLoaderLifecycleSupport#init(com.hazelcast.core.
      * HazelcastInstance, java.util.Properties, java.lang.String)
@@ -53,5 +49,5 @@ public abstract class MapStoreBase implements MapLoaderLifecycleSupport {
         this.allowLoadAll = Boolean.parseBoolean(properties.getProperty(ALLOW_LOAD_ALL, "false"));
         this.allowDelete = Boolean.parseBoolean(properties.getProperty(ALLOW_DELETE, "false"));
     }
-    
+
 }

--- a/src/main/java/com/mozilla/bagheera/hazelcast/persistence/MultiMapStore.java
+++ b/src/main/java/com/mozilla/bagheera/hazelcast/persistence/MultiMapStore.java
@@ -33,9 +33,9 @@ import com.hazelcast.core.MapLoaderLifecycleSupport;
 import com.hazelcast.core.MapStore;
 
 /**
- * A MultiMapStore consists of any number of MapStore implementations specified via Hazelcast config. This consists of 
+ * A MultiMapStore consists of any number of MapStore implementations specified via Hazelcast config. This consists of
  * setting configuration properties that specify the MapStore implementation to use that begin with MULTI_MAP_STORE_PREFIX.
- * 
+ *
  * Example:
  * <map-store enabled="true">
  *  <class-name>com.mozilla.bagheera.hazelcast.persistence.MultiMapStore</class-name>
@@ -44,18 +44,18 @@ import com.hazelcast.core.MapStore;
  *  ...
  * </map-store>
  */
-public class MultiMapStore extends MapStoreBase implements MapStore<String, String>, MapLoaderLifecycleSupport {
+public class MultiMapStore extends MapStoreBase implements MapStore<String, String> {
 
     private static final Logger LOG = Logger.getLogger(MultiMapStore.class);
-    
+
     private static final String MULTI_MAP_STORE_PREFIX = "hazelcast.multi.store.class.name";
-    
+
     private List<MapStore<String,String>> mapStores;
-    
+
     @SuppressWarnings("unchecked")
     public void init(HazelcastInstance hazelcastInstance, Properties properties, String mapName) {
         super.init(hazelcastInstance, properties, mapName);
-        
+
         mapStores = new ArrayList<MapStore<String,String>>();
         for (Map.Entry<Object, Object> prop : properties.entrySet()) {
             Object ko = prop.getKey();
@@ -86,7 +86,7 @@ public class MultiMapStore extends MapStoreBase implements MapStore<String, Stri
             }
         }
     }
-    
+
     @Override
     public void destroy() {
         for (MapStore<String,String> ms : mapStores) {
@@ -95,7 +95,7 @@ public class MultiMapStore extends MapStoreBase implements MapStore<String, Stri
             }
         }
     }
-    
+
     @Override
     public String load(String key) {
         // TODO Auto-generated method stub
@@ -117,13 +117,13 @@ public class MultiMapStore extends MapStoreBase implements MapStore<String, Stri
     @Override
     public void delete(String key) {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override
     public void deleteAll(Collection<String> keys) {
         // TODO Auto-generated method stub
-        
+
     }
 
     @Override

--- a/src/main/java/com/mozilla/bagheera/rest/HazelcastMapResource.java
+++ b/src/main/java/com/mozilla/bagheera/rest/HazelcastMapResource.java
@@ -60,7 +60,7 @@ import com.hazelcast.core.Hazelcast;
 public class HazelcastMapResource extends ResourceBase {
 
 	private static final Logger LOG = Logger.getLogger(HazelcastMapResource.class);
-	
+
 	private static final String MAX_BYTES_POSTFIX = ".max.bytes";
 	private static final String ALLOW_GET_ACCESS = ".allow.get.access";
 	private static final String POST_RESPONSE = ".post.response";
@@ -68,7 +68,7 @@ public class HazelcastMapResource extends ResourceBase {
 	private final JsonFactory jsonFactory;
 	private Properties props;
 	private Set<String> validMapNames;
-	
+
 	public HazelcastMapResource() throws IOException {
 		super();
 		jsonFactory = new JsonFactory();
@@ -93,7 +93,7 @@ public class HazelcastMapResource extends ResourceBase {
 		    validMapNames = new HashSet<String>();
 		}
 	}
-	
+
 	/**
 	 * A REST POST that generates an id and put the id,data pair into a map with the given name.
 	 * @param name
@@ -104,10 +104,10 @@ public class HazelcastMapResource extends ResourceBase {
 	@POST
 	@Path("{name}")
 	@Consumes(MediaType.APPLICATION_JSON)
-	public Response mapPut(@PathParam("name") String name, @Context HttpServletRequest request) throws IOException {	
+	public Response mapPut(@PathParam("name") String name, @Context HttpServletRequest request) throws IOException {
 		return mapPut(name, UUID.randomUUID().toString(), request);
 	}
-	
+
 	/**
 	 * A REST POST that puts the id,data pair into the map with the given name.
 	 * @param name
@@ -132,7 +132,7 @@ public class HazelcastMapResource extends ResourceBase {
 		if (maxByteSize > 0 && request.getContentLength() > maxByteSize) {
 			return Response.status(Status.NOT_ACCEPTABLE).build();
 		}
-		
+
 		// Read in the JSON data straight from the request
 		BufferedReader reader = new BufferedReader(new InputStreamReader(request.getInputStream()), 8192);
 		String line = null;
@@ -140,7 +140,7 @@ public class HazelcastMapResource extends ResourceBase {
 		while ((line = reader.readLine()) != null) {
 			sb.append(line);
 		}
-		
+
 		// Validate JSON (open schema)
 		JsonParser parser = jsonFactory.createJsonParser(sb.toString());
 		JsonToken token = null;
@@ -154,19 +154,19 @@ public class HazelcastMapResource extends ResourceBase {
 			// if this was hit we'll return below
 			LOG.error("Error parsing JSON", e);
 		}
-		
+
 		if (!parseSucceeded) {
 			return Response.status(Status.NOT_ACCEPTABLE).build();
 		}
-		
+
 		Map<String,String> m = Hazelcast.getMap(name);
 		m.put(id, sb.toString());
-		
+
 		boolean postResponse = Boolean.parseBoolean(props.getProperty(name + POST_RESPONSE, "false"));
 		if (postResponse) {
 		    return Response.created(URI.create(id)).build();
 		}
-		
+
 		return Response.noContent().build();
 	}
 
@@ -178,7 +178,7 @@ public class HazelcastMapResource extends ResourceBase {
 	    if (!allowGetAccess) {
 	        return Response.status(Status.FORBIDDEN).build();
 	    }
-	    
+
 	    Map<String,String> m = Hazelcast.getMap(name);
 	    // This won't have any fields filled out other than the payload
 	    String data = m.get(id);
@@ -188,7 +188,7 @@ public class HazelcastMapResource extends ResourceBase {
 	    } else {
 	        resp = Response.status(Status.NOT_FOUND).build();
 	    }
-	    
+
 	    return resp;
 	}
 }


### PR DESCRIPTION
- more load/loadAll/delete impls, especially for ElasticSearch
- allow multiple maps to use the same mapstore configuration 
  (use HC wildcards: http://www.hazelcast.com/docs/1.9.4/manual/multi_html/ch09s06.html)
