### PR TITLE
Keyvalue size too large

### DIFF
--- a/src/main/java/com/mozilla/bagheera/consumer/KafkaConsumer.java
+++ b/src/main/java/com/mozilla/bagheera/consumer/KafkaConsumer.java
@@ -103,6 +103,7 @@ public class KafkaConsumer implements Consumer {
         this.validationPipeline = pipeline;
     }
     
+    @Override
     public void close() {
         LOG.info("Shutting down!");
         if (executor != null) {
@@ -134,6 +135,7 @@ public class KafkaConsumer implements Consumer {
         } 
     }
     
+    @Override
     public void poll() {
         final CountDownLatch latch = new CountDownLatch(streams.size());
         for (final KafkaStream<Message> stream : streams) {  
@@ -154,6 +156,7 @@ public class KafkaConsumer implements Consumer {
                                 bmsg.hasId() && bmsg.hasPayload()) {
                                 if (validationPipeline == null ||
                                     validationPipeline.isValid(bmsg.getPayload().toByteArray())) {
+                                    // TODO ^ check for "java.lang.IllegalArgumentException: KeyValue size too large" in sink.store.
                                     if (bmsg.hasTimestamp()) {
                                         sink.store(bmsg.getId(), bmsg.getPayload().toByteArray(), bmsg.getTimestamp());
                                     } else {
@@ -161,6 +164,7 @@ public class KafkaConsumer implements Consumer {
                                     }
                                 } else {
                                     invalidMessageMeter.mark();
+                                    // TODO: sample out an example payload
                                     LOG.warn("Invalid payload for namespace: " + bmsg.getNamespace());
                                 }
                             } else if (bmsg.getOperation() == Operation.DELETE &&

--- a/src/main/java/com/mozilla/bagheera/http/AccessFilter.java
+++ b/src/main/java/com/mozilla/bagheera/http/AccessFilter.java
@@ -46,7 +46,7 @@ public class AccessFilter extends SimpleChannelUpstreamHandler {
     }    
 
     private String buildErrorMessage(String msg, HttpRequest request, MessageEvent e) {
-        return String.format("%s: %s - \"%s\" \"%s\"", msg, request.getUri(), 
+        return String.format("%s: %s %s - \"%s\" \"%s\"", msg, request.getMethod().getName(), request.getUri(), 
                              HttpUtil.getRemoteAddr(request, ((InetSocketAddress)e.getChannel().getRemoteAddress()).toString()), 
                              request.getHeader(HttpUtil.USER_AGENT));
     }

--- a/src/main/java/com/mozilla/bagheera/sink/HBaseSink.java
+++ b/src/main/java/com/mozilla/bagheera/sink/HBaseSink.java
@@ -43,28 +43,29 @@ import com.yammer.metrics.core.Timer;
 import com.yammer.metrics.core.TimerContext;
 
 public class HBaseSink implements KeyValueSink {
-    
+
     private static final Logger LOG = Logger.getLogger(HBaseSink.class);
 
     private static final int DEFAULT_POOL_SIZE = Runtime.getRuntime().availableProcessors();
-    
+
     protected long sleepTime = 1000L;
-    
+
     protected HTablePool hbasePool;
-    
+
     protected final byte[] tableName;
     protected final byte[] family;
     protected final byte[] qualifier;
-    
+
     protected boolean prefixDate = true;
     protected int batchSize = 100;
-    
+    protected long maxKeyValueSize;
+
     protected AtomicInteger putsQueueSize = new AtomicInteger();
-    protected ConcurrentLinkedQueue<Put> putsQueue = new ConcurrentLinkedQueue<Put>(); 
-    
+    protected ConcurrentLinkedQueue<Put> putsQueue = new ConcurrentLinkedQueue<Put>();
+
     protected final Meter stored;
     protected final Timer flushTimer;
-    
+
     public HBaseSink(SinkConfiguration sinkConfiguration) {
         this(sinkConfiguration.getString("hbasesink.hbase.tablename"),
              sinkConfiguration.getString("hbasesink.hbase.column.family", "data"),
@@ -72,20 +73,23 @@ public class HBaseSink implements KeyValueSink {
              sinkConfiguration.getBoolean("hbasesink.hbase.rowkey.prefixdate", false),
              sinkConfiguration.getInt("hbasesink.hbase.numthreads", DEFAULT_POOL_SIZE));
     }
-    
+
     public HBaseSink(String tableName, String family, String qualifier, boolean prefixDate, int numThreads) {
         this.tableName = Bytes.toBytes(tableName);
         this.family = Bytes.toBytes(family);
         this.qualifier = Bytes.toBytes(qualifier);
         this.prefixDate = prefixDate;
-        
+
         Configuration conf = HBaseConfiguration.create();
+
+        // Use the standard HBase default
+        maxKeyValueSize = conf.getLong("hbase.client.keyvalue.maxsize", 10485760l);
         hbasePool = new HTablePool(conf, numThreads);
-        
+
         stored = Metrics.newMeter(new MetricName("bagheera", "sink.hbase", tableName + ".stored"), "messages", TimeUnit.SECONDS);
         flushTimer = Metrics.newTimer(new MetricName("bagheera", "sink.hbase", tableName + ".flush.time"), TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
     }
-    
+
     @Override
     public void close() {
         if (hbasePool != null) {
@@ -126,31 +130,18 @@ public class HBaseSink implements KeyValueSink {
 
     @Override
     public void store(String key, byte[] data) throws IOException {
+        // There's a max size for 'data', exceeding causes
+        //   java.lang.IllegalArgumentException: KeyValue size too large
+        // Detect, log, and reject it.
+        if (data != null && data.length > maxKeyValueSize) {
+            LOG.warn(String.format("Storing key '%s': Data exceeds max length (%d > %d)",
+                    key, data.length, maxKeyValueSize));
+            return;
+        }
+
         Put p = new Put(Bytes.toBytes(key));
-        // TODO There's a max size for 'data', exceeding causes java.lang.IllegalArgumentException: KeyValue size too large
-        //      Figure out how to split it up or detect / reject it.
-        // TODO Same with the other 'store' method below.
-//        2013-03-11 12:35:38,994 ERROR com.mozilla.bagheera.consumer.KafkaConsumer: Exception occured in thread:
-//            java.util.concurrent.ExecutionException: java.lang.IllegalArgumentException: KeyValue size too large
-//                at java.util.concurrent.FutureTask$Sync.innerGet(FutureTask.java:232)
-//                at java.util.concurrent.FutureTask.get(FutureTask.java:91)
-//                at com.mozilla.bagheera.consumer.KafkaConsumer.poll(KafkaConsumer.java:205)
-//                at com.mozilla.bagheera.consumer.KafkaHBaseConsumer.main(KafkaHBaseConsumer.java:81)
-//            Caused by: java.lang.IllegalArgumentException: KeyValue size too large
-//                at org.apache.hadoop.hbase.client.HTable.validatePut(HTable.java:896)
-//                at org.apache.hadoop.hbase.client.HTable.doPut(HTable.java:704)
-//                at org.apache.hadoop.hbase.client.HTable.put(HTable.java:698)
-//                at com.mozilla.bagheera.sink.HBaseSink.flush(HBaseSink.java:115)
-//                at com.mozilla.bagheera.sink.HBaseSink.store(HBaseSink.java:143)
-//                at com.mozilla.bagheera.consumer.KafkaConsumer$1.call(KafkaConsumer.java:158)
-//                at com.mozilla.bagheera.consumer.KafkaConsumer$1.call(KafkaConsumer.java:1)
-//                at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
-//                at java.util.concurrent.FutureTask.run(FutureTask.java:138)
-//                at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
-//                at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
-//                at java.lang.Thread.run(Thread.java:662)
         p.add(family, qualifier, data);
-        putsQueue.add(p);      
+        putsQueue.add(p);
         if (putsQueueSize.incrementAndGet() >= batchSize) {
             flush();
         }
@@ -158,6 +149,15 @@ public class HBaseSink implements KeyValueSink {
 
     @Override
     public void store(String key, byte[] data, long timestamp) throws IOException {
+        // There's a max size for 'data', exceeding causes
+        //   java.lang.IllegalArgumentException: KeyValue size too large
+        // Detect, log, and reject it.
+        if (data != null && data.length > maxKeyValueSize) {
+            LOG.warn(String.format("Storing key '%s': Data exceeds max length (%d > %d)",
+                    key, data.length, maxKeyValueSize));
+            return;
+        }
+
         byte[] k = prefixDate ? IdUtil.bucketizeId(key, timestamp) : Bytes.toBytes(key);
         Put p = new Put(k);
         p.add(family, qualifier, data);


### PR DESCRIPTION
Handle an error case where submitted payloads are too large for HBase to accept.  This change causes these large payloads to be skipped (and a log message to be emitted).
