### PR TITLE
Add handling for multiple X-Obsolete-Doc headers

### DIFF
--- a/src/main/java/com/mozilla/bagheera/http/SubmissionHandler.java
+++ b/src/main/java/com/mozilla/bagheera/http/SubmissionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 Mozilla Foundation
+ * Copyright 2013 Mozilla Foundation
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,11 +21,11 @@ package com.mozilla.bagheera.http;
 
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH;
 import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static org.jboss.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.CREATED;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.OK;
 import static org.jboss.netty.handler.codec.http.HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE;
@@ -34,6 +34,7 @@ import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.channels.ClosedChannelException;
+import java.util.List;
 
 import org.apache.log4j.Logger;
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -63,15 +64,17 @@ import com.mozilla.bagheera.validation.Validator;
 
 public class SubmissionHandler extends SimpleChannelUpstreamHandler {
 
+    public static final String HEADER_OBSOLETE_DOCUMENT = "X-Obsolete-Document";
+
     private static final Logger LOG = Logger.getLogger(SubmissionHandler.class);
 
     // REST endpoints
-    private static final String ENDPOINT_SUBMIT = "submit";
+    public static final String ENDPOINT_SUBMIT = "submit";
 
     private final Producer producer;
     private final ChannelGroup channelGroup;
     private final MetricsManager metricsManager;
-    
+
     public SubmissionHandler(Validator validator,
                              Producer producer,
                              ChannelGroup channelGroup,
@@ -80,7 +83,7 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
         this.channelGroup = channelGroup;
         this.metricsManager = metricsManager;
     }
- 
+
     private void updateRequestMetrics(String namespace, String method, int size) {
         this.metricsManager.getHttpMetricForNamespace(namespace).updateRequestMetrics(method, size);
         this.metricsManager.getGlobalHttpMetric().updateRequestMetrics(method, size);
@@ -92,7 +95,7 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
         }
         this.metricsManager.getGlobalHttpMetric().updateResponseMetrics(status);
     }
-    
+
     private void handlePost(MessageEvent e, BagheeraHttpRequest request) {
         HttpResponseStatus status = BAD_REQUEST;
         ChannelBuffer content = request.getContent();
@@ -101,43 +104,73 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
             BagheeraMessage.Builder bmsgBuilder = BagheeraMessage.newBuilder();
             bmsgBuilder.setNamespace(request.getNamespace());
             bmsgBuilder.setId(request.getId());
-            bmsgBuilder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request, 
+            bmsgBuilder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request,
                                                                              ((InetSocketAddress)e.getChannel().getRemoteAddress()).getAddress())));
             bmsgBuilder.setPayload(ByteString.copyFrom(content.toByteBuffer()));
             bmsgBuilder.setTimestamp(System.currentTimeMillis());
             producer.send(bmsgBuilder.build());
-            
-            if (request.containsHeader("X-Obsolete-Document")) {
-                String obsoleteId = request.getHeader("X-Obsolete-Document");
-                BagheeraMessage.Builder obsBuilder = BagheeraMessage.newBuilder();
-                obsBuilder.setOperation(Operation.DELETE);
-                obsBuilder.setNamespace(request.getNamespace());
-                obsBuilder.setId(obsoleteId);
-                obsBuilder.setIpAddr(bmsgBuilder.getIpAddr());
-                obsBuilder.setTimestamp(bmsgBuilder.getTimestamp());
-                producer.send(obsBuilder.build());
+
+            if (request.containsHeader(HEADER_OBSOLETE_DOCUMENT)) {
+                handleObsoleteDocuments(request.getHeaders(HEADER_OBSOLETE_DOCUMENT),
+                        request.getNamespace(), bmsgBuilder.getIpAddr(), bmsgBuilder.getTimestamp());
             }
-            
+
             status = CREATED;
         }
 
         updateRequestMetrics(request.getNamespace(), request.getMethod().getName(), content.readableBytes());
         writeResponse(status, e, request.getNamespace(), URI.create(request.getId()).toString());
     }
-    
+
+    private void handleObsoleteDocuments(List<String> headers, String namespace, ByteString ipAddress, long timestamp) {
+        // According to RFC 2616, the standard for multi-valued document headers is
+        // a comma-separated list:
+        // http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
+        //  ------------------------------------------------------------------
+        //   Multiple message-header fields with the same field-name MAY be
+        //   present in a message if and only if the entire field-value for
+        //   that header field is defined as a comma-separated list
+        //   [i.e., #(values)]. It MUST be possible to combine the multiple
+        //   header fields into one "field-name: field-value" pair, without
+        //   changing the semantics of the message, by appending each
+        //   subsequent field-value to the first, each separated by a comma.
+        //   The order in which header fields with the same field-name are
+        //   received is therefore significant to the interpretation of the
+        //   combined field value, and thus a proxy MUST NOT change the order
+        //   of these field values when a message is forwarded.
+        //  ------------------------------------------------------------------
+        for (String header : headers) {
+            // Split on comma, delete each one.
+            // The performance penalty for supporting multiple values is
+            // tested in BagheeraHttpRequestTest.testSplitPerformance().
+            if (header != null) {
+                for (String obsoleteIdRaw : header.split(",")) {
+                    String obsoleteId = obsoleteIdRaw.trim();
+                    BagheeraMessage.Builder obsBuilder = BagheeraMessage.newBuilder();
+                    obsBuilder.setOperation(Operation.DELETE);
+                    obsBuilder.setNamespace(namespace);
+                    obsBuilder.setId(obsoleteId);
+                    obsBuilder.setIpAddr(ipAddress);
+                    obsBuilder.setTimestamp(timestamp);
+                    producer.send(obsBuilder.build());
+                }
+            }
+        }
+    }
+
     private void handleDelete(MessageEvent e, BagheeraHttpRequest request) {
         BagheeraMessage.Builder bmsgBuilder = BagheeraMessage.newBuilder();
         bmsgBuilder.setOperation(Operation.DELETE);
         bmsgBuilder.setNamespace(request.getNamespace());
         bmsgBuilder.setId(request.getId());
-        bmsgBuilder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request, 
+        bmsgBuilder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request,
                                                                          ((InetSocketAddress)e.getChannel().getRemoteAddress()).getAddress())));
         bmsgBuilder.setTimestamp(System.currentTimeMillis());
         producer.send(bmsgBuilder.build());
         updateRequestMetrics(request.getNamespace(), request.getMethod().getName(), 0);
         writeResponse(OK, e, request.getNamespace(), null);
     }
-    
+
     private void writeResponse(HttpResponseStatus status, MessageEvent e, String namespace, String entity) {
         // Build the response object.
         HttpResponse response = new DefaultHttpResponse(HTTP_1_1, status);
@@ -151,7 +184,7 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
         // Write response
         ChannelFuture future = e.getChannel().write(response);
         future.addListener(ChannelFutureListener.CLOSE);
-        
+
         updateResponseMetrics(namespace, response.getStatus().getCode());
     }
 
@@ -159,7 +192,7 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
     public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent e) {
         this.channelGroup.add(e.getChannel());
     }
-    
+
     @Override
     public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
         Object msg = e.getMessage();
@@ -203,12 +236,12 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
             LOG.error(cause.getMessage());
             response = new DefaultHttpResponse(HTTP_1_1, INTERNAL_SERVER_ERROR);
         }
-        
+
         if (response != null) {
             ChannelFuture future = e.getChannel().write(response);
             future.addListener(ChannelFutureListener.CLOSE);
             updateResponseMetrics(null, response.getStatus().getCode());
         }
     }
-    
+
 }

--- a/src/test/java/com/mozilla/bagheera/http/BagheeraHttpRequestTest.java
+++ b/src/test/java/com/mozilla/bagheera/http/BagheeraHttpRequestTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2013 Mozilla Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mozilla.bagheera.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.Date;
+import java.util.List;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.group.ChannelGroup;
+import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import scala.actors.threadpool.Arrays;
+
+import com.mozilla.bagheera.BagheeraProto.BagheeraMessage;
+import com.mozilla.bagheera.BagheeraProto.BagheeraMessage.Operation;
+import com.mozilla.bagheera.metrics.HttpMetric;
+import com.mozilla.bagheera.metrics.MetricsManager;
+import com.mozilla.bagheera.producer.Producer;
+import com.mozilla.bagheera.util.HttpUtil;
+import com.mozilla.bagheera.validation.Validator;
+
+public class BagheeraHttpRequestTest {
+    private Validator validator;
+    private DummyProducer producer;
+    private ChannelGroup channelGroup;
+    private MetricsManager manager;
+    private Channel mockChannel;
+    private ChannelBuffer mockChannelBuffer;
+    private ChannelFuture mockFuture;
+
+    @Before
+    public void setup() {
+        validator = Mockito.mock(Validator.class);
+        producer = new DummyProducer() ;
+
+        channelGroup = Mockito.mock(ChannelGroup.class);
+        manager = Mockito.mock(MetricsManager.class);
+        HttpMetric metric = Mockito.mock(HttpMetric.class);
+        Mockito.when(manager.getGlobalHttpMetric()).thenReturn(metric);
+        Mockito.when(manager.getHttpMetricForNamespace(Mockito.anyString())).thenReturn(metric);
+
+        mockChannelBuffer = Mockito.mock(ChannelBuffer.class);
+        Mockito.when(mockChannelBuffer.readable()).thenReturn(true);
+        Mockito.when(mockChannelBuffer.readableBytes()).thenReturn(1);
+        Mockito.when(mockChannelBuffer.toByteBuffer()).thenReturn(ByteBuffer.allocate(1));
+
+        mockChannel = Mockito.mock(Channel.class);
+        mockFuture = Mockito.mock(ChannelFuture.class);
+        Mockito.when(mockChannel.getRemoteAddress()).thenReturn(new InetSocketAddress("localhost", 8080));
+        Mockito.when(mockChannel.write(Mockito.any())).thenReturn(mockFuture);
+
+        // We get a NoClassDefFoundError without this.
+        if (!new File("./target/classes/com/mozilla/bagheera/BagheeraProto.class").exists()) {
+            fail("You must run 'mvn compile' before the tests will run properly from Eclipse");
+        }
+    }
+
+    private BagheeraHttpRequest getMockMessage(HttpMethod method, String id, boolean includeObsoleteDocHeader, String... deletes) {
+        BagheeraHttpRequest message = Mockito.mock(BagheeraHttpRequest.class);
+        Mockito.when(message.getHeader(HttpUtil.X_FORWARDED_FOR)).thenReturn(null);
+        Mockito.when(message.getEndpoint()).thenReturn(SubmissionHandler.ENDPOINT_SUBMIT);
+        Mockito.when(message.getMethod()).thenReturn(method);
+        Mockito.when(message.getContent()).thenReturn(mockChannelBuffer);
+        Mockito.when(message.getNamespace()).thenReturn("test");
+        Mockito.when(message.getId()).thenReturn(id);
+        Mockito.when(message.containsHeader(SubmissionHandler.HEADER_OBSOLETE_DOCUMENT)).thenReturn(includeObsoleteDocHeader);
+        if (deletes != null && deletes.length > 0) {
+            @SuppressWarnings("unchecked")
+            List<String> deleteList = Arrays.asList(deletes);
+            Mockito.when(message.getHeader(SubmissionHandler.HEADER_OBSOLETE_DOCUMENT)).thenReturn(deleteList.get(0));
+            Mockito.when(message.getHeaders(SubmissionHandler.HEADER_OBSOLETE_DOCUMENT)).thenReturn(deleteList);
+        }
+
+        return message;
+    }
+
+    @Test
+    public void testPostWithoutDelete() throws Exception {
+        testMessage("create-id", false, 0, 1);
+    }
+
+    @Test
+    public void testPostWithDeleteSingle() throws Exception {
+        // Each message should result in 1 delete and 1 create
+        testMessage("single-delete-id", true, 1, 1, "deadbeef");
+    }
+
+    @Test
+    public void testPostWithDeleteMulti() throws Exception {
+        // Test a a single X-Obsolete-Doc header with a comma-separated list:
+        testMessage("multi-delete-id-comma", true, 2, 1, "deadbeef, livebeef"); // 2 items
+
+        // Test multiple X-Obsolete-Doc headers:
+        testMessage("multi-delete-id-list", true, 3, 1, "deadbeef", "livebeef", "morebeef"); // 3 items
+
+        // Test a combination:
+        testMessage("multi-delete-id-list", true, 5, 1, "deadbeef", "livebeef, morebeef, potatoes", "oranges"); // 5 items
+    }
+
+    // Ensure that one invocation of the message results in the specified number of deletes and creates
+    // and that two invocations results in double those numbers.
+    private void testMessage(String id, boolean doDelete, int expectedDeletes, int expectedCreates, String... deletes) throws Exception {
+        SubmissionHandler handler = new SubmissionHandler(validator, producer, channelGroup, manager);
+        ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
+        MessageEvent messageEvent = Mockito.mock(MessageEvent.class);
+        Mockito.when(messageEvent.getChannel()).thenReturn(mockChannel);
+        BagheeraHttpRequest mockMessage = getMockMessage(HttpMethod.POST, id, doDelete, deletes);
+        Mockito.when(messageEvent.getMessage()).thenReturn(mockMessage);
+
+        testTwoInvocations(expectedDeletes, expectedCreates, handler, context,
+                messageEvent);
+
+        producer.reset();
+    }
+
+    private void testTwoInvocations(int expectedDeletes, int expectedCreates,
+            SubmissionHandler handler, ChannelHandlerContext context,
+            MessageEvent messageEvent) throws Exception {
+        handler.messageReceived(context, messageEvent);
+        assertEquals(expectedDeletes, producer.getDeleteCount());
+        assertEquals(expectedCreates, producer.getCreateCount());
+
+        handler.messageReceived(context, messageEvent);
+        assertEquals(expectedDeletes * 2, producer.getDeleteCount());
+        assertEquals(expectedCreates * 2, producer.getCreateCount());
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        // Test an actual delete (as opposed to a POST message with an X-Obsolete-Doc header).
+        SubmissionHandler handler = new SubmissionHandler(validator, producer, channelGroup, manager);
+        ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
+        MessageEvent messageEvent = Mockito.mock(MessageEvent.class);
+        Mockito.when(messageEvent.getChannel()).thenReturn(mockChannel);
+        BagheeraHttpRequest mockMessage = getMockMessage(HttpMethod.DELETE, "delete-id", false);
+        Mockito.when(messageEvent.getMessage()).thenReturn(mockMessage);
+
+        testTwoInvocations(1, 0, handler, context, messageEvent);
+
+        producer.reset();
+    }
+
+    private int dummyNoSplit(String msg) {
+        return msg.length();
+    }
+
+    private int dummySplit(String msg) {
+        String[] split = msg.split(",");
+        return split[0].trim().length();
+    }
+
+    @Test
+    public void testSplitPerformance() {
+        // Ensure that the change to support multiple X-Obsolete-Doc headers
+        // does not have a large negative impact on performance.
+        int numIterations = 1000000;
+
+        long totalLength = 0;
+        long start = new Date().getTime();
+        String msg = "foooooooooo";
+        for (int i = 0; i < numIterations; i++) {
+            totalLength += dummyNoSplit(msg);
+        }
+        long finish = new Date().getTime();
+
+        long noSplitDuration = finish - start;
+
+        start = new Date().getTime();
+        for (int i = 0; i < numIterations; i++) {
+            totalLength -= dummySplit(msg);
+        }
+        finish = new Date().getTime();
+        long splitDuration = finish - start;
+
+        assertEquals(0, totalLength);
+
+        long durationDiff = Math.abs(noSplitDuration - splitDuration);
+
+        // Make sure the difference in execution time is less than 0.5ms per iteration.
+        double diffPerIteration = (double)durationDiff / numIterations;
+        assertTrue(diffPerIteration <= 0.5);
+
+        System.out.println(String.format("Without split, it took %d.  With split, it took %d.  Splitting was %d ms %s (%.05f ms per iteration)",
+                noSplitDuration, splitDuration, durationDiff, (noSplitDuration < splitDuration ? "slower" : "faster"), diffPerIteration));
+    }
+}
+
+class DummyProducer implements Producer {
+    private int deleteCount = 0;
+    private int createCount = 0;
+
+    @Override
+    public void close() throws IOException { }
+
+    public void reset() {
+        deleteCount = 0;
+        createCount = 0;
+    }
+
+    @Override
+    public void send(BagheeraMessage msg) {
+        if (msg.getOperation() == Operation.CREATE_UPDATE) {
+            setCreateCount(getCreateCount() + 1);
+        } else if(msg.getOperation() == Operation.DELETE) {
+            setDeleteCount(getDeleteCount() + 1);
+        }
+    }
+
+    public int getDeleteCount() {
+        return deleteCount;
+    }
+
+    public void setDeleteCount(int deleteCount) {
+        this.deleteCount = deleteCount;
+    }
+
+    public int getCreateCount() {
+        return createCount;
+    }
+
+    public void setCreateCount(int createCount) {
+        this.createCount = createCount;
+    }
+}


### PR DESCRIPTION
Multiple values can be specified either using multiple headers, or by passing
a single header with a comma-separated list of doc ids.
