### PR TITLE
Bagheera partitions

### DIFF
--- a/src/main/java/com/mozilla/bagheera/http/BagheeraHttpRequest.java
+++ b/src/main/java/com/mozilla/bagheera/http/BagheeraHttpRequest.java
@@ -22,6 +22,7 @@ package com.mozilla.bagheera.http;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import org.jboss.netty.handler.codec.http.DefaultHttpRequest;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -30,10 +31,8 @@ import org.jboss.netty.handler.codec.http.HttpVersion;
 
 public class BagheeraHttpRequest extends DefaultHttpRequest {
 
-    // Version constants
-    // TODO: make version a Pattern of ^[0-9]+([.][0-9]+)?$
-    public static final String VERSION_1_0 = "1.0";
-    public static final String VERSION_1 = "1";
+    // API Version
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^[0-9]+([.][0-9]+)?$");
 
     // REST path indices
     public static final int ENDPOINT_PATH_IDX = 0;
@@ -61,8 +60,7 @@ public class BagheeraHttpRequest extends DefaultHttpRequest {
 
         String apiVersionIn = pathDecoder.getPathElement(0);
         // If API version is in the path then offset the path indices
-        if (VERSION_1_0.equals(apiVersionIn) ||
-            VERSION_1.equals(apiVersionIn)) {
+        if (isApiVersion(apiVersionIn)) {
             idxOffset = 1;
             apiVersion = apiVersionIn;
         } else {
@@ -85,6 +83,10 @@ public class BagheeraHttpRequest extends DefaultHttpRequest {
         for (int i = partitionOffset; i < pathDecoder.size(); i++) {
             partitions.add(pathDecoder.getPathElement(i));
         }
+    }
+
+    public boolean isApiVersion(String possibleApiVersion) {
+        return VERSION_PATTERN.matcher(possibleApiVersion).matches();
     }
 
     public String getEndpoint() {

--- a/src/main/java/com/mozilla/bagheera/http/PathDecoder.java
+++ b/src/main/java/com/mozilla/bagheera/http/PathDecoder.java
@@ -27,9 +27,9 @@ import java.util.regex.Pattern;
 public class PathDecoder {
 
     private static final Pattern PATH_PATTERN = Pattern.compile("/([^/]+)");
-    
+
     private List<String> pathElements = new ArrayList<String>();
-    
+
     public PathDecoder(String uri) {
         Matcher m = PATH_PATTERN.matcher(uri);
         while (m.find()) {
@@ -42,5 +42,9 @@ public class PathDecoder {
     public String getPathElement(int idx) {
         return idx < pathElements.size() ? pathElements.get(idx) : null;
     }
-    
+
+    public int size() {
+        return pathElements.size();
+    }
+
 }

--- a/src/main/java/com/mozilla/bagheera/http/SubmissionHandler.java
+++ b/src/main/java/com/mozilla/bagheera/http/SubmissionHandler.java
@@ -101,10 +101,18 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
         ChannelBuffer content = request.getContent();
 
         if (content.readable() && content.readableBytes() > 0) {
-            // TODO: insert apiVersion and partition info
             BagheeraMessage.Builder bmsgBuilder = BagheeraMessage.newBuilder();
             bmsgBuilder.setNamespace(request.getNamespace());
             bmsgBuilder.setId(request.getId());
+            if (request.getApiVersion() != null) {
+                bmsgBuilder.setApiVersion(request.getApiVersion());
+            }
+            List<String> partitions = request.getPartitions();
+            if (partitions != null) {
+                for (int i = 0; i < partitions.size(); i++) {
+                    bmsgBuilder.setPartition(i, partitions.get(i));
+                }
+            }
             bmsgBuilder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request,
                                                                              ((InetSocketAddress)e.getChannel().getRemoteAddress()).getAddress())));
             bmsgBuilder.setPayload(ByteString.copyFrom(content.toByteBuffer()));

--- a/src/main/java/com/mozilla/bagheera/http/SubmissionHandler.java
+++ b/src/main/java/com/mozilla/bagheera/http/SubmissionHandler.java
@@ -102,19 +102,6 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
 
         if (content.readable() && content.readableBytes() > 0) {
             BagheeraMessage.Builder templateBuilder = BagheeraMessage.newBuilder();
-//            templateBuilder.setNamespace(request.getNamespace());
-//            if (request.getApiVersion() != null) {
-//                templateBuilder.setApiVersion(request.getApiVersion());
-//            }
-//            List<String> partitions = request.getPartitions();
-//            if (partitions != null) {
-//                for (int i = 0; i < partitions.size(); i++) {
-//                    templateBuilder.setPartition(i, partitions.get(i));
-//                }
-//            }
-//            templateBuilder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request,
-//                                                                             ((InetSocketAddress)e.getChannel().getRemoteAddress()).getAddress())));
-//            templateBuilder.setTimestamp(System.currentTimeMillis());
             setMessageFields(request, e, templateBuilder, System.currentTimeMillis(), false);
             BagheeraMessage template = templateBuilder.buildPartial();
 

--- a/src/main/java/com/mozilla/bagheera/http/SubmissionHandler.java
+++ b/src/main/java/com/mozilla/bagheera/http/SubmissionHandler.java
@@ -101,28 +101,30 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
         ChannelBuffer content = request.getContent();
 
         if (content.readable() && content.readableBytes() > 0) {
-            BagheeraMessage.Builder bmsgBuilder = BagheeraMessage.newBuilder();
-            bmsgBuilder.setNamespace(request.getNamespace());
-            bmsgBuilder.setId(request.getId());
-            if (request.getApiVersion() != null) {
-                bmsgBuilder.setApiVersion(request.getApiVersion());
-            }
-            List<String> partitions = request.getPartitions();
-            if (partitions != null) {
-                for (int i = 0; i < partitions.size(); i++) {
-                    bmsgBuilder.setPartition(i, partitions.get(i));
-                }
-            }
-            bmsgBuilder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request,
-                                                                             ((InetSocketAddress)e.getChannel().getRemoteAddress()).getAddress())));
-            bmsgBuilder.setPayload(ByteString.copyFrom(content.toByteBuffer()));
-            bmsgBuilder.setTimestamp(System.currentTimeMillis());
-            producer.send(bmsgBuilder.build());
+            BagheeraMessage.Builder templateBuilder = BagheeraMessage.newBuilder();
+//            templateBuilder.setNamespace(request.getNamespace());
+//            if (request.getApiVersion() != null) {
+//                templateBuilder.setApiVersion(request.getApiVersion());
+//            }
+//            List<String> partitions = request.getPartitions();
+//            if (partitions != null) {
+//                for (int i = 0; i < partitions.size(); i++) {
+//                    templateBuilder.setPartition(i, partitions.get(i));
+//                }
+//            }
+//            templateBuilder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request,
+//                                                                             ((InetSocketAddress)e.getChannel().getRemoteAddress()).getAddress())));
+//            templateBuilder.setTimestamp(System.currentTimeMillis());
+            setMessageFields(request, e, templateBuilder, System.currentTimeMillis(), false);
+            BagheeraMessage template = templateBuilder.buildPartial();
+
+            BagheeraMessage.Builder storeBuilder = BagheeraMessage.newBuilder(template);
+            storeBuilder.setPayload(ByteString.copyFrom(content.toByteBuffer()));
+            storeBuilder.setId(request.getId());
+            producer.send(storeBuilder.build());
 
             if (request.containsHeader(HEADER_OBSOLETE_DOCUMENT)) {
-                // TODO: insert apiVersion and partition info (unless we don't care about partitions for deletes)
-                handleObsoleteDocuments(request.getHeaders(HEADER_OBSOLETE_DOCUMENT),
-                        request.getNamespace(), bmsgBuilder.getIpAddr(), bmsgBuilder.getTimestamp());
+                handleObsoleteDocuments(request.getHeaders(HEADER_OBSOLETE_DOCUMENT), template);
             }
 
             status = CREATED;
@@ -132,7 +134,26 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
         writeResponse(status, e, request.getNamespace(), URI.create(request.getId()).toString());
     }
 
-    private void handleObsoleteDocuments(List<String> headers, String namespace, ByteString ipAddress, long timestamp) {
+    protected void setMessageFields(BagheeraHttpRequest request, MessageEvent event, BagheeraMessage.Builder builder, long timestamp, boolean setId) {
+        builder.setNamespace(request.getNamespace());
+        if (request.getApiVersion() != null) {
+            builder.setApiVersion(request.getApiVersion());
+        }
+
+        List<String> partitions = request.getPartitions();
+        if (partitions != null && !partitions.isEmpty()) {
+            builder.addAllPartition(partitions);
+        }
+
+        builder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request, ((InetSocketAddress)event.getChannel().getRemoteAddress()).getAddress())));
+        builder.setTimestamp(timestamp);
+
+        if (setId) {
+            builder.setId(request.getId());
+        }
+    }
+
+    private void handleObsoleteDocuments(List<String> headers, BagheeraMessage template) {
         // According to RFC 2616, the standard for multi-valued document headers is
         // a comma-separated list:
         // http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
@@ -155,28 +176,20 @@ public class SubmissionHandler extends SimpleChannelUpstreamHandler {
             // tested in BagheeraHttpRequestTest.testSplitPerformance().
             if (header != null) {
                 for (String obsoleteIdRaw : header.split(",")) {
-                    String obsoleteId = obsoleteIdRaw.trim();
-                    BagheeraMessage.Builder obsBuilder = BagheeraMessage.newBuilder();
-                    obsBuilder.setOperation(Operation.DELETE);
-                    obsBuilder.setNamespace(namespace);
-                    obsBuilder.setId(obsoleteId);
-                    obsBuilder.setIpAddr(ipAddress);
-                    obsBuilder.setTimestamp(timestamp);
-                    producer.send(obsBuilder.build());
+                    // Use the given message as a base for creating each delete message.
+                    BagheeraMessage.Builder deleteBuilder = BagheeraMessage.newBuilder(template);
+                    deleteBuilder.setOperation(Operation.DELETE);
+                    deleteBuilder.setId(obsoleteIdRaw.trim());
+                    producer.send(deleteBuilder.build());
                 }
             }
         }
     }
 
     private void handleDelete(MessageEvent e, BagheeraHttpRequest request) {
-        // TODO: insert apiVersion and partition info (unless we don't care about partitions for deletes)
         BagheeraMessage.Builder bmsgBuilder = BagheeraMessage.newBuilder();
+        setMessageFields(request, e, bmsgBuilder, System.currentTimeMillis(), true);
         bmsgBuilder.setOperation(Operation.DELETE);
-        bmsgBuilder.setNamespace(request.getNamespace());
-        bmsgBuilder.setId(request.getId());
-        bmsgBuilder.setIpAddr(ByteString.copyFrom(HttpUtil.getRemoteAddr(request,
-                                                                         ((InetSocketAddress)e.getChannel().getRemoteAddress()).getAddress())));
-        bmsgBuilder.setTimestamp(System.currentTimeMillis());
         producer.send(bmsgBuilder.build());
         updateRequestMetrics(request.getNamespace(), request.getMethod().getName(), 0);
         writeResponse(OK, e, request.getNamespace(), null);

--- a/src/main/java/com/mozilla/bagheera/sink/ReplaySink.java
+++ b/src/main/java/com/mozilla/bagheera/sink/ReplaySink.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import org.apache.log4j.Logger;
 
 // TODO: should we queue up deletes and combine them with "store" requests using the "X-Obsolete-Doc" header?
+// TODO: create placeholders for API version, partitions, etc.
 
 public class ReplaySink implements Sink, KeyValueSink {
 

--- a/src/main/proto/bagheera_message.proto
+++ b/src/main/proto/bagheera_message.proto
@@ -17,6 +17,6 @@ message BagheeraMessage {
 		DELETE = 1;
 	}
 	optional Operation operation = 7 [default = CREATE_UPDATE];
-	optional string api_version = 8 [default = "1"];
+	optional string api_version = 8;
 	repeated string partition = 9;
 }

--- a/src/main/proto/bagheera_message.proto
+++ b/src/main/proto/bagheera_message.proto
@@ -17,6 +17,6 @@ message BagheeraMessage {
 		DELETE = 1;
 	}
 	optional Operation operation = 7 [default = CREATE_UPDATE];
-	optional string api_version = 8 [default = 1];
-	optional repeated string partition = 9;
+	optional string api_version = 8 [default = "1"];
+	repeated string partition = 9;
 }

--- a/src/main/proto/bagheera_message.proto
+++ b/src/main/proto/bagheera_message.proto
@@ -16,5 +16,7 @@ message BagheeraMessage {
 		CREATE_UPDATE = 0;
 		DELETE = 1;
 	}
-	optional Operation operation = 7 [default = CREATE_UPDATE]; 
+	optional Operation operation = 7 [default = CREATE_UPDATE];
+	optional string api_version = 8 [default = 1];
+	optional repeated string partition = 9;
 }

--- a/src/test/java/com/mozilla/bagheera/http/AccessFilterTest.java
+++ b/src/test/java/com/mozilla/bagheera/http/AccessFilterTest.java
@@ -55,7 +55,7 @@ public class AccessFilterTest {
     private ChannelHandlerContext ctx;
     private InetSocketAddress remoteAddr;
     private AccessFilter filter;
-    
+
     @Before
     public void setup() throws IOException {
         String[] namespaces = new String[] { "foo_*", "bar" };
@@ -67,32 +67,32 @@ public class AccessFilterTest {
         InputStream is = new ByteArrayInputStream(propsFileStr.getBytes("UTF-8"));
         props.load(is);
         filter = new AccessFilter(new Validator(namespaces), props);
-        
+
         remoteAddr = InetSocketAddress.createUnresolved("192.168.1.1", 51723);
-        
+
         Channel channel = createMock(Channel.class);
         expect(channel.getCloseFuture()).andReturn(new DefaultChannelFuture(channel, false));
         expect(channel.getRemoteAddress()).andReturn(remoteAddr);
-        
+
         OrderedMemoryAwareThreadPoolExecutor executor = new OrderedMemoryAwareThreadPoolExecutor(10, 0L, 0L);
         final ExecutionHandler handler = new ExecutionHandler(executor, true, true);
-        
+
         ctx = new FakeChannelHandlerContext(channel, handler);
     }
-    
-    private MessageEvent createMockEvent(Channel channel, HttpVersion protocolVersion, HttpMethod method, String uri) {    
+
+    private MessageEvent createMockEvent(Channel channel, HttpVersion protocolVersion, HttpMethod method, String uri) {
         MessageEvent event = createMock(UpstreamMessageEvent.class);
         expect(event.getChannel()).andReturn(channel).anyTimes();
         expect(event.getFuture()).andReturn(new DefaultChannelFuture(channel,false)).anyTimes();
         expect(event.getRemoteAddress()).andReturn(remoteAddr);
         expect(event.getMessage()).andReturn(new BagheeraHttpRequest(protocolVersion, method, uri));
         replay(channel, event);
-        
+
         return event;
     }
-    
+
     @Test
-    public void testInvalidNamespace() throws Exception {        
+    public void testInvalidNamespace() throws Exception {
         boolean success = false;
         try {
             filter.messageReceived(ctx, createMockEvent(ctx.getChannel(), HTTP_1_1, POST, "/bad"));
@@ -101,7 +101,7 @@ public class AccessFilterTest {
         }
         assertTrue(success);
     }
-    
+
     @Test
     public void testInvalidId() throws Exception {
         boolean success = false;
@@ -112,7 +112,7 @@ public class AccessFilterTest {
         }
         assertTrue(success);
     }
-    
+
     @Test
     public void testGetAccessDenied() throws Exception {
         boolean success = false;
@@ -123,9 +123,9 @@ public class AccessFilterTest {
         }
         assertTrue(success);
     }
-    
+
     @Test
-    public void testDeleteAccessGranted() throws Exception {        
+    public void testDeleteAccessGranted() throws Exception {
         boolean success = false;
         try {
             filter.messageReceived(ctx, createMockEvent(ctx.getChannel(), HTTP_1_1, DELETE, "/submit/bar/" + UUID.randomUUID().toString()));
@@ -134,7 +134,7 @@ public class AccessFilterTest {
         }
         assertTrue(success);
     }
-    
+
     @Test
     public void testDeleteAccessDenied() throws Exception {
         boolean success = false;

--- a/src/test/java/com/mozilla/bagheera/http/BagheeraHttpRequestTest.java
+++ b/src/test/java/com/mozilla/bagheera/http/BagheeraHttpRequestTest.java
@@ -1,0 +1,53 @@
+package com.mozilla.bagheera.http;
+
+import static org.jboss.netty.handler.codec.http.HttpMethod.POST;
+import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.Test;
+
+public class BagheeraHttpRequestTest {
+    @Test
+    public void testURIParsing() {
+        String apiVersion = "1.0";
+        String namespace = "bar";
+        String endpoint = SubmissionHandler.ENDPOINT_SUBMIT;
+        String id = "bogusid";
+        String partitions = "part1/part2/part3";
+
+        String uri = String.format("/%s/%s/%s/%s/%s", apiVersion, endpoint, namespace, id, partitions);
+        BagheeraHttpRequest req = new BagheeraHttpRequest(HTTP_1_1, POST, uri);
+        assertEquals(apiVersion, req.getApiVersion());
+        assertEquals(namespace, req.getNamespace());
+        assertEquals(endpoint, req.getEndpoint());
+        assertEquals(id, req.getId());
+        List<String> reqPartitions = req.getPartitions();
+        assertEquals("part1", reqPartitions.get(0));
+        assertEquals("part2", reqPartitions.get(1));
+        assertEquals("part3", reqPartitions.get(2));
+
+        req = new BagheeraHttpRequest(HTTP_1_1, POST, String.format("/%s/%s/%s", endpoint, namespace, id));
+        assertEquals(null, req.getApiVersion());
+        assertEquals(namespace, req.getNamespace());
+        assertEquals(endpoint, req.getEndpoint());
+        assertEquals(id, req.getId());
+        assertEquals(0, req.getPartitions().size());
+
+        req = new BagheeraHttpRequest(HTTP_1_1, POST, String.format("/%s/%s", endpoint, namespace));
+        assertEquals(null, req.getApiVersion());
+        assertEquals(namespace, req.getNamespace());
+        assertEquals(endpoint, req.getEndpoint());
+        // Should have an auto-assigned id:
+        String randomId = req.getId();
+        assertEquals(UUID.randomUUID().toString().length(), randomId.length());
+        assertTrue(randomId.matches("^[0-9a-f-]{36}$"));
+        UUID uuid = UUID.fromString(randomId);
+        assertTrue(uuid != null);
+        assertEquals(0, req.getPartitions().size());
+    }
+
+}

--- a/src/test/java/com/mozilla/bagheera/http/BagheeraHttpRequestTest.java
+++ b/src/test/java/com/mozilla/bagheera/http/BagheeraHttpRequestTest.java
@@ -48,6 +48,13 @@ public class BagheeraHttpRequestTest {
         UUID uuid = UUID.fromString(randomId);
         assertTrue(uuid != null);
         assertEquals(0, req.getPartitions().size());
+
+        String[] possibleVersions = new String[]{"no",   "1",  "2",  "3",  "1.2", "9.999", "",    "1.2.3", "123", "123.456", "bogus.bogus"};
+        boolean[] areTheyVersions = new boolean[]{false, true, true, true, true,  true,    false, false,   true,  true,      false};
+
+        for (int i = 0; i < possibleVersions.length; i++) {
+            assertEquals(areTheyVersions[i], req.isApiVersion(possibleVersions[i]));
+        }
     }
 
 }

--- a/src/test/java/com/mozilla/bagheera/http/BagheeraTest.java
+++ b/src/test/java/com/mozilla/bagheera/http/BagheeraTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2013 Mozilla Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mozilla.bagheera.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.mozilla.bagheera.BagheeraProto.BagheeraMessage;
+import com.mozilla.bagheera.http.Bagheera.BagheeraServerState;
+import com.mozilla.bagheera.metrics.MetricsManager;
+import com.mozilla.bagheera.producer.Producer;
+import com.mozilla.bagheera.sink.ReplaySink;
+import com.mozilla.bagheera.util.WildcardProperties;
+
+
+public class BagheeraTest {
+    private static final int BAGHEERA_PORT = 8999;
+    private static final String TEST_NAMESPACE = "test";
+    BagheeraServerState state;
+    SimpleProducer producer = new SimpleProducer();
+    WildcardProperties props = new WildcardProperties();
+    Properties metricsProps = new Properties();
+    MetricsManager manager = new MetricsManager(metricsProps, "foo.");
+
+    String json = "{\"test\":\"bagheera\"}";
+    String key = UUID.randomUUID().toString();
+    long timestamp = new Date().getTime();
+
+    @Before
+    public void setup() throws Exception {
+        props.put("valid.namespaces", TEST_NAMESPACE);
+
+        state = Bagheera.startServer(BAGHEERA_PORT, false, props, producer,
+                Bagheera.getChannelFactory(), Bagheera.class.getName(), manager);
+    }
+
+    @Test
+    public void testBasicMessage() throws IOException, InterruptedException {
+        // Use a ReplaySink to send messages
+        String destPattern = String.format("http://localhost:%d/%s/%s/%s", BAGHEERA_PORT, SubmissionHandler.ENDPOINT_SUBMIT, TEST_NAMESPACE, ReplaySink.KEY_PLACEHOLDER);
+        ReplaySink sink = new ReplaySink(destPattern, "1", "true", "true");
+        sink.store(key, json.getBytes(), timestamp);
+
+        assertEquals(1, producer.queueSize());
+        BagheeraMessage message = producer.getQueue().poll();
+        String payload = message.getPayload().toStringUtf8();
+        assertEquals(json, payload);
+
+        // ReplaySink doesn't preserve timestamps.
+        assertNotSame(timestamp, message.getTimestamp());
+
+        assertEquals(key, message.getId());
+        assertEquals("", message.getApiVersion());
+    }
+
+    @Test
+    public void testMessageWithPartitions() throws IOException, InterruptedException {
+        // Use a ReplaySink to send messages
+        String destPattern = String.format("http://localhost:%d/%s/%s/%s/partition1/partition2", BAGHEERA_PORT, SubmissionHandler.ENDPOINT_SUBMIT, TEST_NAMESPACE, ReplaySink.KEY_PLACEHOLDER);
+        ReplaySink sink = new ReplaySink(destPattern, "1", "true", "true");
+        sink.store(key, json.getBytes(), timestamp);
+
+        assertEquals(1, producer.queueSize());
+        BagheeraMessage message = producer.getQueue().poll();
+        String payload = message.getPayload().toStringUtf8();
+        assertEquals(json, payload);
+
+        // ReplaySink doesn't preserve timestamps.
+        assertNotSame(timestamp, message.getTimestamp());
+
+        assertEquals(key, message.getId());
+
+        // Ensure that partition information comes through.
+        assertEquals(2, message.getPartitionCount());
+        assertEquals("partition1", message.getPartition(0));
+        assertEquals("partition2", message.getPartition(1));
+
+    }
+
+
+    @Test
+    public void testMessageWithApiVersion() throws IOException, InterruptedException {
+        // Use a ReplaySink to send messages
+        String destPattern = String.format("http://localhost:%d/5.5/%s/%s/%s/partition1/partition2", BAGHEERA_PORT, SubmissionHandler.ENDPOINT_SUBMIT, TEST_NAMESPACE, ReplaySink.KEY_PLACEHOLDER);
+        ReplaySink sink = new ReplaySink(destPattern, "1", "true", "true");
+        sink.store(key, json.getBytes(), timestamp);
+
+        assertEquals(1, producer.queueSize());
+        BagheeraMessage message = producer.getQueue().poll();
+        String payload = message.getPayload().toStringUtf8();
+        assertEquals(json, payload);
+
+        // ReplaySink doesn't preserve timestamps.
+        assertNotSame(timestamp, message.getTimestamp());
+
+        assertEquals(key, message.getId());
+
+        // Ensure that partition information comes through.
+        assertEquals(2, message.getPartitionCount());
+        assertEquals("partition1", message.getPartition(0));
+        assertEquals("partition2", message.getPartition(1));
+
+        assertEquals("5.5", message.getApiVersion());
+    }
+
+    @After
+    public void tearDown() {
+        state.close();
+    }
+}
+
+class SimpleProducer implements Producer {
+    private final int maxQueueSize;
+    private final LinkedList<BagheeraMessage> queue = new LinkedList<BagheeraMessage>();
+
+    public SimpleProducer(int queueSize) {
+        maxQueueSize = queueSize;
+    }
+
+    public SimpleProducer() {
+        this(1000);
+    }
+
+    public LinkedList<BagheeraMessage> getQueue() {
+        return queue;
+    }
+
+    public int queueSize() {
+        return queue.size();
+    }
+
+    @Override
+    public void close() throws IOException { }
+
+    @Override
+    public void send(BagheeraMessage msg) {
+        // Remove & discard some to make room.
+        while (queue.size() >= maxQueueSize) {
+            queue.poll();
+        }
+        queue.offer(msg);
+    }
+}

--- a/src/test/java/com/mozilla/bagheera/http/PathDecoderTest.java
+++ b/src/test/java/com/mozilla/bagheera/http/PathDecoderTest.java
@@ -19,7 +19,8 @@
  */
 package com.mozilla.bagheera.http;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -32,6 +33,14 @@ public class PathDecoderTest {
         assertEquals("foo", pd.getPathElement(1));
         assertEquals("fakeid", pd.getPathElement(2));
         assertNull(pd.getPathElement(3));
-    }
 
+        assertEquals(3, pd.size());
+
+
+        pd = new PathDecoder("/1/2/3/4/5/6/7/8/9/10");
+        for (int i = 1; i <= 10; i++) {
+            assertEquals(String.valueOf(i), pd.getPathElement(i-1));
+        }
+        assertEquals(10, pd.size());
+    }
 }

--- a/src/test/java/com/mozilla/bagheera/http/SubmissionHandlerTest.java
+++ b/src/test/java/com/mozilla/bagheera/http/SubmissionHandlerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2013 Mozilla Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mozilla.bagheera.http;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.MessageEvent;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.mozilla.bagheera.BagheeraProto.BagheeraMessage;
+import com.mozilla.bagheera.util.HttpUtil;
+
+
+public class SubmissionHandlerTest {
+
+    @Test
+    public void testSetFields() throws Exception {
+        SubmissionHandler handler = new SubmissionHandler(null, null, null, null);
+        BagheeraMessage.Builder builder = BagheeraMessage.newBuilder();
+        BagheeraMessage before = builder.buildPartial();
+
+        assertEquals("", before.getId());
+        assertEquals("", before.getNamespace());
+        assertEquals("", before.getApiVersion());
+        assertEquals(0, before.getPartitionCount());
+        assertEquals(0l, before.getTimestamp());
+
+        String expectedNamespace = "test";
+        String expectedApiVersion = "2.5";
+        String expectedId = "hello there";
+        long expectedTimestamp = System.currentTimeMillis();
+        List<String> expectedPartitions = new ArrayList<String>();
+
+        BagheeraHttpRequest request = Mockito.mock(BagheeraHttpRequest.class);
+        Mockito.when(request.getNamespace()).thenReturn(expectedNamespace);
+        Mockito.when(request.getApiVersion()).thenReturn(expectedApiVersion);
+        Mockito.when(request.getId()).thenReturn(expectedId);
+        Mockito.when(request.getPartitions()).thenReturn(expectedPartitions);
+
+        // Make sure we don't interrogate the mocked InetSocketAddress below.
+        Mockito.when(request.getHeader(HttpUtil.X_FORWARDED_FOR)).thenReturn("123.123.123.123");
+
+        MessageEvent event = Mockito.mock(MessageEvent.class);
+        Channel channel = Mockito.mock(Channel.class);
+        Mockito.when(event.getChannel()).thenReturn(channel);
+
+        InetSocketAddress address = Mockito.mock(InetSocketAddress.class);
+        Mockito.when(channel.getRemoteAddress()).thenReturn(address);
+
+        // Do not set the ID
+        handler.setMessageFields(request, event, builder, expectedTimestamp, false);
+
+        BagheeraMessage after = builder.build();
+        assertEquals("", after.getId()); // <-- missing ID
+        assertEquals(expectedNamespace, after.getNamespace());
+        assertEquals(expectedApiVersion, after.getApiVersion());
+        assertEquals(0, after.getPartitionCount());
+        assertEquals(expectedTimestamp, after.getTimestamp());
+
+        builder = BagheeraMessage.newBuilder();
+        // This time, *do* set the ID
+        handler.setMessageFields(request, event, builder, expectedTimestamp, true);
+
+        after = builder.build();
+        assertEquals(expectedId, after.getId()); // <-- ID has been set.
+        assertEquals(expectedNamespace, after.getNamespace());
+        assertEquals(expectedApiVersion, after.getApiVersion());
+        assertEquals(0, after.getPartitionCount());
+        assertEquals(expectedTimestamp, after.getTimestamp());
+
+        // Test without specifying an apiVersion
+        Mockito.when(request.getApiVersion()).thenReturn(null);
+        builder = BagheeraMessage.newBuilder();
+
+        handler.setMessageFields(request, event, builder, expectedTimestamp, true);
+
+        after = builder.build();
+        assertEquals(expectedId, after.getId()); // <-- ID has been set.
+        assertEquals(expectedNamespace, after.getNamespace());
+        assertEquals("", after.getApiVersion());
+        assertEquals(0, after.getPartitionCount());
+        assertEquals(expectedTimestamp, after.getTimestamp());
+
+        // Test with some partitions
+        expectedPartitions.add("hello");
+        expectedPartitions.add("goodbye");
+
+        Mockito.when(request.getPartitions()).thenReturn(expectedPartitions);
+
+        builder = BagheeraMessage.newBuilder();
+
+        assertEquals(0, builder.getPartitionCount());
+        handler.setMessageFields(request, event, builder, expectedTimestamp, true);
+        after = builder.build();
+        assertEquals(expectedPartitions.size(), after.getPartitionCount());
+        for (int i = 0; i < expectedPartitions.size(); i++) {
+            assertEquals(expectedPartitions.get(i), after.getPartition(i));
+        }
+    }
+}

--- a/src/test/java/com/mozilla/bagheera/producer/ProducerTest.java
+++ b/src/test/java/com/mozilla/bagheera/producer/ProducerTest.java
@@ -216,6 +216,7 @@ public class ProducerTest {
         for (int i = content.length(); i < payloadSize; i++) {
             content.append(i % 10);
         }
+        bmsgBuilder.addPartition(String.valueOf(messageNumber));
         bmsgBuilder.setPayload(ByteString.copyFrom(content.toString().getBytes()));
         bmsgBuilder.setTimestamp(System.currentTimeMillis());
         return bmsgBuilder.build();


### PR DESCRIPTION
This adds two optional things to the BagheeraMessage payloads.  First, the api_version which can optionally be provided at the beginning of the URL path, and second, a repeating series of zero or more 'partition' strings.  This allows you to provide and fetch small amounts of information without having to parse the main payload.
