### PR TITLE
Set the batch size to improve throughput

### DIFF
--- a/bin/start_consumers
+++ b/bin/start_consumers
@@ -10,9 +10,9 @@ HDFS_CONSUMER_CLASS=com.mozilla.bagheera.consumer.KafkaSequenceFileConsumer
 FHR_CONSUMER_CLASS=com.mozilla.fhr.consumer.FHRConsumer
 
 # Telemetry
-$bin/consumer $HBASE_CONSUMER_CLASS -t telemetry -gid telemetry-hbase-prod -p $CONSUMER_PROPS --validatejson --table telemetry --family data --qualifier json --prefixdate
+$bin/consumer $HBASE_CONSUMER_CLASS -t telemetry -gid telemetry-hbase-prod -p $CONSUMER_PROPS --validatejson --table telemetry --family data --qualifier json --prefixdate --batchsize 1000
 # FHR (does its own json validation so option isn't needed)
-HADOOP_DISTRO=CDH4 $bin/consumer $FHR_CONSUMER_CLASS -t metrics -gid fhr-hbase-prod -p $CONSUMER_PROPS --table metrics --family data --qualifier json --numthreads 4
+HADOOP_DISTRO=CDH4 $bin/consumer $FHR_CONSUMER_CLASS -t metrics -gid fhr-hbase-prod -p $CONSUMER_PROPS --table metrics --family data --qualifier json --numthreads 4 --batchsize 2000
 # Testpilot
 $bin/consumer $HDFS_CONSUMER_CLASS -t testpilot_.+ -gid testpilot-hdfs-prod -p $CONSUMER_PROPS --validatejson 
 # Marketplace


### PR DESCRIPTION
Processing messages with a larger batch size (increased from the default of
100 to 1000 for telemetry and 2000 for FHR) has a large positive effect on
throughput.  More than a 2x speedup for Telemetry and maybe 3-5x speedup for
FHR.

Increasing Telemetry batch size from 1000 to 2000 didn't cause a significant
improvement in tests today (July 11, 2013).
