### PR TITLE
Given that failed ops will be retried by the consumer, it is unnecessary...

### DIFF
--- a/src/main/java/com/mozilla/bagheera/sink/HBaseSink.java
+++ b/src/main/java/com/mozilla/bagheera/sink/HBaseSink.java
@@ -143,7 +143,7 @@ public class HBaseSink implements KeyValueSink {
         for (i = 0; i < getRetryCount(); i++) {
             HTableInterface table = hbasePool.getTable(tableName);
             try {
-                table.setAutoFlush(false);
+                table.setAutoFlush(false, true);
                 final TimerContext flushTimerContext = flushTimer.time();
                 try {
                     List<Row> rows = new ArrayList<Row>(batchSize);


### PR DESCRIPTION
... (and perhaps error-prone) to retain them in the HBase client buffers
